### PR TITLE
crashes from corrupted jpg image

### DIFF
--- a/Fast Image Viewer Standalone/MainWindow.xaml.cs
+++ b/Fast Image Viewer Standalone/MainWindow.xaml.cs
@@ -952,7 +952,9 @@ namespace FIVStandard
 
             if (!selectedNew)//this should be called only when selecting new image from the thumbnail list
             {
-                await ChangeImage(0, true);
+                try{
+                    await ChangeImage(0, true);
+                }catch {}
             }
         }
 


### PR DESCRIPTION
## What ? 
Adding try-catch block when calling MagickImage to open an image /  when selecting a new image from the thumbnail list

## Why ?
MagickImage package causes the app to crash when opening corrupted jpg file / when selecting corrupted jpg file from thumbnail list.
